### PR TITLE
Updated url() to path()

### DIFF
--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
 from django.contrib import admin
+from django.urls import path
 
 urlpatterns = [
-  url(r'^admin/', admin.site.urls),
+  path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
url() is deprecated in Django 3.2.