### PR TITLE
Removed inheritance from `object`

### DIFF
--- a/cities_light/downloader.py
+++ b/cities_light/downloader.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 from .exceptions import SourceFileDoesNotExist
 
 
-class Downloader(object):
+class Downloader:
 
     """Geonames data downloader class."""
 

--- a/cities_light/geonames.py
+++ b/cities_light/geonames.py
@@ -8,7 +8,7 @@ from .settings import *
 from .downloader import Downloader
 
 
-class Geonames(object):
+class Geonames:
     logger = logging.getLogger('cities_light')
 
     def __init__(self, url, force=False):

--- a/cities_light/tests/base.py
+++ b/cities_light/tests/base.py
@@ -9,7 +9,7 @@ from django.core import management
 from django.conf import settings
 
 
-class FixtureDir(object):
+class FixtureDir:
     """Helper class to construct fixture paths."""
 
     def __init__(self, rel_path='', base_dir=None):


### PR DESCRIPTION
No longer required with Python 3