### PR TITLE
Django 3.1 deprecated features. 

### DIFF
--- a/cities_light/abstract_models.py
+++ b/cities_light/abstract_models.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.db.models import lookups
 from django.utils.encoding import force_str
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from unidecode import unidecode
 

--- a/cities_light/signals.py
+++ b/cities_light/signals.py
@@ -71,17 +71,15 @@ __all__ = [
     'city_items_pre_import', 'city_items_post_import',
     'translation_items_pre_import']
 
-city_items_pre_import = django.dispatch.Signal(providing_args=['items'])
-subregion_items_pre_import = django.dispatch.Signal(providing_args=['items'])
-region_items_pre_import = django.dispatch.Signal(providing_args=['items'])
-country_items_pre_import = django.dispatch.Signal(providing_args=['items'])
-translation_items_pre_import = django.dispatch.Signal(providing_args=['items'])
+# providing_args=['items'] for signals below
+city_items_pre_import = django.dispatch.Signal()
+subregion_items_pre_import = django.dispatch.Signal()
+region_items_pre_import = django.dispatch.Signal()
+country_items_pre_import = django.dispatch.Signal()
+translation_items_pre_import = django.dispatch.Signal()
 
-city_items_post_import = django.dispatch.Signal(
-    providing_args=['instance', 'items'])
-subregion_items_post_import = django.dispatch.Signal(
-    providing_args=['instance', 'items'])
-region_items_post_import = django.dispatch.Signal(
-    providing_args=['instance', 'items'])
-country_items_post_import = django.dispatch.Signal(
-    providing_args=['instance', 'items'])
+# providing_args=['instance', 'items'] for all signals below
+city_items_post_import = django.dispatch.Signal()
+subregion_items_post_import = django.dispatch.Signal()
+region_items_post_import = django.dispatch.Signal()
+country_items_post_import = django.dispatch.Signal()


### PR DESCRIPTION
Django 3.1 raises a couple of deprecation warnings. This fixes two items:

1) ugettext_lazy is deprecated in favor of gettext_lazy
2) Signal args were for information only and are now deprecated. I've kept these as a comment instead. 