### PR TITLE
Updated tox for deprecated option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands =
     mysql: mysql -u root -e 'drop database if exists test_cities_light_test;'
     postgresql: psql -U postgres -c 'drop database if exists test_cities_light_test;'
     py.test -v --cov cities_light --create-db --strict -r fEsxXw {posargs:cities_light}
-whitelist_externals =
+allowlist_externals =
     mysql
     psql
 deps =
@@ -108,4 +108,4 @@ deps =
     {[docs]deps}
 changedir = docs
 commands = make html
-whitelist_externals = make
+allowlist_externals = make


### PR DESCRIPTION
The current version of tox has deprecated "whitelist_externals" in favor of "allowlist_externals"

https://tox.readthedocs.io/en/latest/config.html#conf-allowlist_externals
