### PR TITLE
Dropped support for Django versions prior to 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
   - env: TOXENV=py37-djangodev-postgresql
   include:
   - python: 3.7
-    env: TOXENV=py37-django20-sqlite
-  - python: 3.7
     env: TOXENV=py37-django22-sqlite
   - python: 3.7
     env: TOXENV=py37-django30-sqlite

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+TBD -- Next release
+    Drop support of Django 2.0 and 2.1
+
 2020-08-28 3.8.0
     Fix for subregion #229
     Documentation improvement #221 #189

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ database, you should use
 Requirements:
 
 - Python >= 3.6
-- Django >= 2.0
+- Django >= 2.2
 - MySQL or PostgreSQL or SQLite.
 
 Yes, for some reason, code that used to work on MySQL (not without pain xD)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36, 37,38}-django{20,22,30,31}{-sqlite,-mysql,-postgresql},
+    py{35,36, 37,38}-django{22,30,31}{-sqlite,-mysql,-postgresql},
     py{35,36, 37,38}-djangodev{-sqlite,-mysql,-postgresql},
     checkqa,
     pylint,
@@ -59,7 +59,6 @@ allowlist_externals =
     psql
 deps =
     {[test]deps}
-    django20: Django>=2.0,<2.1
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2


### PR DESCRIPTION
In line with Django's supported versions policy, only Django 2.2 and later is supported. Can therefore remove testing against Django 2.0.

https://www.djangoproject.com/download/